### PR TITLE
Add plugin UUID

### DIFF
--- a/MonitoringClient/Plugins/_wm_temp.plist
+++ b/MonitoringClient/Plugins/_wm_temp.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>PluginName</key>
 	<string>_Temperature and Fan Speed</string>
+	<key>PluginUUID</key>
+	<string>e546a0c2-27c9-4fc9-bafc-c1d03a5fb2c9</string>
 	<key>PluginVersion</key>
 	<string>0.6.0.0</string>
 	<key>ProgramArguments</key>


### PR DESCRIPTION
Hey Dan!

We're adding plugin UUIDs, and have assigned one to you.

Note that at this time, you are welcome to rename your plugin (there's no longer a need to prefix it with an `_`. If you do plan to rename the plugin, just let us know so we can make adjustments.
